### PR TITLE
Example of abstracting the Maven pipeline

### DIFF
--- a/.github/workflows/install-frsca.yaml
+++ b/.github/workflows/install-frsca.yaml
@@ -86,3 +86,11 @@ jobs:
           cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 
           kubectl wait --timeout=5m --for=condition=ready pods -l app=picalc -n prod
+      - name: Run maven pipeline
+        run: |
+          make example-maven
+          tkn pr logs --last -f
+          if [ "$(tkn pr describe --last -o jsonpath='{.status.conditions[?(@.type == "Succeeded")].status}')" != "True" ]; then
+            tkn pr describe --last
+            exit 1
+          fi

--- a/examples/examples-maven.cue
+++ b/examples/examples-maven.cue
@@ -1,0 +1,7 @@
+package frsca
+
+import "github.com/buildsec/frsca/examples/pipelines/maven"
+
+#ExampleMaven: e=#Example & {
+	frsca: (maven & {"id": e.id, "sourceUrl": e.sourceUrl}).frsca
+}

--- a/examples/examples.cue
+++ b/examples/examples.cue
@@ -1,5 +1,14 @@
 package frsca
 
+#Example: {
+	image: name: string | *"example"
+	repository: *"ttl.sh" | string @tag(repository)
+	appImage: *"\(repository)/\(image.name)" | string @tag(appImage)
+	id: string
+	sourceUrl: string
+	frsca?: _
+}
+
 _IMAGE: name: string
 
 _REPOSITORY: *"ttl.sh" | string @tag(repository)
@@ -37,7 +46,7 @@ frsca: clusterRoleBinding: "pipeline-role-binding": {
 }
 
 // generate a PVC for each pipelineRun
-for pr in frsca.pipelineRun {
+if frsca.pipelineRun != _|_ for pr in frsca.pipelineRun {
 	frsca: persistentVolumeClaim: "\(pr.metadata.generateName)source-ws-pvc": {
 		spec: {
 			accessModes: ["ReadWriteOnce"]
@@ -46,7 +55,7 @@ for pr in frsca.pipelineRun {
 	}
 }
 
-frsca: pipelineRun: [Name=_]: spec: workspaces: [{
+frsca: pipelineRun?: [Name=_]: spec: workspaces: [{
 	name: *"\(Name)ws" | string
 	persistentVolumeClaim: claimName: "\(Name)source-ws-pvc"
 }, ...]

--- a/examples/maven/maven-pkg.cue
+++ b/examples/maven/maven-pkg.cue
@@ -1,1 +1,6 @@
 package frsca
+
+#ExampleMaven & {
+	id:        "maven-test-pipeline"
+	sourceUrl: "https://github.com/buildsec/example-maven"
+}

--- a/examples/maven/maven.sh
+++ b/examples/maven/maven.sh
@@ -12,6 +12,6 @@ C_RESET_ALL='\033[0m'
 # Install the maven pipelinerun.
 echo -e "${C_GREEN}Creating a maven pipelinerun${C_RESET_ALL}"
 pushd "${GIT_ROOT}"/examples/maven
-cue cmd apply | kubectl apply -f -
-cue cmd create | kubectl create -f -
+cue cmd apply :frsca . | kubectl apply -f -
+cue cmd create :frsca . | kubectl create -f -
 popd

--- a/examples/pipelines/maven/maven.cue
+++ b/examples/pipelines/maven/maven.cue
@@ -1,0 +1,80 @@
+package maven
+
+id: string
+sourceUrl: string
+
+_id: id
+_sourceUrl: sourceUrl
+_runName: "\(id)-run-"
+_workspace: "\(_runName)ws"
+_pvc: "\(_runName)source-ws-pvc"
+_mavenSettings: "maven-settings"
+
+frsca: pipelineRun: "\(_runName)": {
+    apiVersion: "tekton.dev/v1beta1"
+    kind: "PipelineRun"
+    metadata: generateName: _runName
+    spec: {
+        pipelineRef: name: _id
+        workspaces: [{
+            name: _workspace
+            persistentVolumeClaim: claimName: _pvc
+        },{
+            name: _mavenSettings
+            emptyDir: {}
+        }]
+    }
+}
+
+frsca: pipeline: "\(_id)": {
+	apiVersion: "tekton.dev/v1beta1"
+	kind:       "Pipeline"
+	metadata: name: _id
+	spec: {
+		workspaces: [{
+			name: _workspace
+		}, {
+			name: _mavenSettings
+		}]
+		tasks: [{
+			name: "fetch-repository"
+			taskRef: name: "git-clone"
+			workspaces: [{
+				name:      "output"
+				workspace: "\(id)-run-ws"
+			}]
+			params: [{
+				name:  "url"
+				value: _sourceUrl
+			}, {
+				name:  "subdirectory"
+				value: ""
+			}, {
+				name:  "deleteExisting"
+				value: "true"
+			}]
+		}, {
+			name: "maven-run"
+			taskRef: name: "maven"
+			runAfter: [
+				"fetch-repository",
+			]
+			params: [{
+				name: "GOALS"
+				value: [
+					"--no-transfer-progress",
+					"-DskipTests",
+					"clean",
+					"package",
+				]
+			}]
+			workspaces: [{
+				name:      _mavenSettings
+				workspace: _mavenSettings
+			}, {
+				name:      "source"
+				workspace: _workspace
+			}]
+		}]
+	}
+}

--- a/examples/pipelines/pipelines.cue
+++ b/examples/pipelines/pipelines.cue
@@ -1,0 +1,1 @@
+package pipelines


### PR DESCRIPTION
An example of abstracting the Maven pipeline so that users are only required to provide the minimum amount of input.