### PR TITLE
check if LibreSSL installed instead of OpenSSL

### DIFF
--- a/platform/06-setup-certs.sh
+++ b/platform/06-setup-certs.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
 
+# Following mainly for MacOS, as supplies LibreSSL by default
+[ $(openssl version|awk '{print$1}') = "LibreSSL" ] && { echo "LibreSSL is not supported, please install Openssl"; exit 1; }
+
 [ -d "${GIT_ROOT}/platform/certs" ] || mkdir -p "${GIT_ROOT}/platform/certs"
 
 ## TODO: if openssl is not installed, consider running command with a temporary container


### PR DESCRIPTION
Hi,

Found an issue with 06-setup-certs.sh on MacOS with default LibreSSL as this does not support option -addext

Installing OpenSSL via Brew, and changing the PATH resolved the issue.

This PR ensures that LibreSSL is not being used, and will fail (exit 1) should that be the case.

Regards,
Jon