### PR TITLE
Update buildpacks pipeline param ENV_VARS

### DIFF
--- a/examples/buildpacks/buildpacks.cue
+++ b/examples/buildpacks/buildpacks.cue
@@ -30,6 +30,9 @@ frsca: pipelineRun: "cache-image-pipelinerun-": spec: {
 	}, {
 		name:  "CACHE_IMAGE"
 		value: _CACHE_IMAGE
+	}, {
+		name: "ENV_VARS"
+		value: [""]
 	}]
 	workspaces: [{
 		name:    "source-ws"


### PR DESCRIPTION
Update the buildpacks pipeline by setting a value for `ENV_VARS` to defend against new behavior in Tekton Pipeline v0.36.0.

Reference: https://github.com/tektoncd/catalog/pull/992

Signed-off-by: Brad Beck <bradley.beck@gmail.com>