### PR TITLE
Use bash in a way that doesn’t assume its location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_NAME = frsca
 TAG ?= 10m	# This is the TTL for the ttl.sh registry
 
 # General.
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 TOPDIR = $(shell git rev-parse --show-toplevel)
 
 # Docker.

--- a/docs/bootstrap.sh
+++ b/docs/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/examples/buildpacks/buildpacks.sh
+++ b/examples/buildpacks/buildpacks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/examples/cosign/cosign.sh
+++ b/examples/cosign/cosign.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/examples/go-pipeline/go-pipeline.sh
+++ b/examples/go-pipeline/go-pipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/examples/gradle-pipeline/gradle-pipeline.sh
+++ b/examples/gradle-pipeline/gradle-pipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/examples/ibm-tutorial/ibm-tutorial.sh
+++ b/examples/ibm-tutorial/ibm-tutorial.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/examples/maven/maven.sh
+++ b/examples/maven/maven.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/examples/sample-pipeline/sample-pipeline.sh
+++ b/examples/sample-pipeline/sample-pipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/platform/00-kubernetes-minikube-setup.sh
+++ b/platform/00-kubernetes-minikube-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # TODO: Pin Brew versions for Mac

--- a/platform/02-setup-certs.sh
+++ b/platform/02-setup-certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/platform/04-registry-setup.sh
+++ b/platform/04-registry-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/platform/05-registry-proxy.sh
+++ b/platform/05-registry-proxy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Port forward the internal registry

--- a/platform/10-tekton-setup.sh
+++ b/platform/10-tekton-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/platform/11-tekton-chains.sh
+++ b/platform/11-tekton-chains.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/platform/12-tekton-tasks.sh
+++ b/platform/12-tekton-tasks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/platform/20-spire-setup.sh
+++ b/platform/20-spire-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -exuo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/platform/25-vault-install.sh
+++ b/platform/25-vault-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/platform/26-vault-setup.sh
+++ b/platform/26-vault-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -exuo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/platform/30-kyverno-setup.sh
+++ b/platform/30-kyverno-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 if kubectl -n vault get configmap frsca-certs >/dev/null 2>&1; then

--- a/platform/31-opa-gatekeeper-setup.sh
+++ b/platform/31-opa-gatekeeper-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 GIT_ROOT=$(git rev-parse --show-toplevel)
 # Update below if you have a different config.json you want to use.

--- a/platform/40-efk-stack-setup/40-efk-stack-setup.sh
+++ b/platform/40-efk-stack-setup/40-efk-stack-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/platform/vendor/vendor-helm-all.sh
+++ b/platform/vendor/vendor-helm-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/platform/vendor/vendor-helm-chart.sh
+++ b/platform/vendor/vendor-helm-chart.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.

--- a/platform/vendor/vendor.sh
+++ b/platform/vendor/vendor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 GIT_ROOT=$(git rev-parse --show-toplevel)

--- a/tools/install-ci.sh
+++ b/tools/install-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Define variables.


### PR DESCRIPTION
Prefer `/usr/bin/env bash` over `/bin/bsh`

Signed-off-by: Brad Beck <bradley.beck@gmail.com>