### PR TITLE
Update shell.nix with more inputs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,9 @@
 with pkgs;
 mkShell {
   buildInputs = [
+    bash
+    git
+    curl
     gnumake
     minikube
     kubectl


### PR DESCRIPTION
Update `shell.nix` to include a more complete list of dependencies. This assumes less about the users install of NixOS.

Currently `docker` is an unlisted dependency because it needs to be setup in `/etc/nixos/configuration.nix` to have the docker daemon available.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>