### PR TITLE
Unignore CVE-2022-30065

### DIFF
--- a/examples/examples.cue
+++ b/examples/examples.cue
@@ -54,9 +54,9 @@ frsca: pipelineRun: [Name=_]: spec: workspaces: [{
 frsca: configMap: "grype-config-map": {
 	data: ".grype.yaml": """
 		ignore:
-		  - vulnerability: CVE-2022-30065
-		    package:
-		      type: apk
+		#  - vulnerability: CVE-2022-30065
+		#    package:
+		#      type: apk
 
 		"""
 }


### PR DESCRIPTION
The `alpine` image has been updated to remove this vulnerability, so there is no longer a reason to ignore it in a Grype scan.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>