### PR TITLE
Moving sample-pipeline to buildsec repo

### DIFF
--- a/examples/sample-pipeline/sample-pipeline.cue
+++ b/examples/sample-pipeline/sample-pipeline.cue
@@ -127,7 +127,7 @@ frsca: pipelineRun: "frsca-lab-pipelinerun-": spec: {
 	pipelineRef: name: "build-and-deploy-pipeline"
 	params: [{
 		name:  "gitUrl"
-		value: "https://github.com/IBM/tekton-tutorial-openshift"
+		value: "https://github.com/buildsec/example-sample-pipeline"
 	}, {
 		name:  "pathToYamlFile"
 		value: "kubernetes/picalc.yaml"


### PR DESCRIPTION
Moving sample-pipeline to use a fork maintained by the buildsec organization.

Signed-off-by: Brandon Mitchell <git@bmitch.net>