### PR TITLE
Moving example-golang-pipeline to buildsec repo

### DIFF
--- a/examples/go-pipeline/go-pipeline.cue
+++ b/examples/go-pipeline/go-pipeline.cue
@@ -21,7 +21,7 @@ frsca: pipeline: "pipeline-go-test": spec: {
 	}, {
 		name:    "package"
 		type:    "string"
-		default: "https://github.com/chmouel/go-rest-api-test"
+		default: "https://github.com/buildsec/example-golang"
 	}]
 	results: [{
 		name:        "commit-sha"


### PR DESCRIPTION
Moving example-golang-pipeline over to the buildsec repo.

Signed-off-by: Brandon Mitchell <git@bmitch.net>