### PR TITLE
Moving example-gradle-pipeline to buildsec repo

### DIFF
--- a/examples/gradle-pipeline/gradle-pipeline.cue
+++ b/examples/gradle-pipeline/gradle-pipeline.cue
@@ -21,7 +21,7 @@ frsca: pipeline: "pipeline-gradle-test": spec: {
 	}, {
 		name:    "package"
 		type:    "string"
-		default: "https://github.com/che-samples/console-java-simple"
+		default: "https://github.com/buildsec/example-gradle"
 	}]
 	results: [{
 		name:        "commit-sha"


### PR DESCRIPTION
Moving example-gradle-pipeline over to the buildsec repo.

Signed-off-by: Brandon Mitchell <git@bmitch.net>