### PR TITLE
Moving example-maven to buildsec repo

### DIFF
--- a/examples/maven/maven.yaml
+++ b/examples/maven/maven.yaml
@@ -16,7 +16,7 @@ spec:
           workspace: maven-test-pipeline-run-ws
       params:
         - name: url
-          value: https://github.com/redhat-scholars/tekton-tutorial-greeter
+          value: https://github.com/buildsec/example-maven
         - name: subdirectory
           value: ""
         - name: deleteExisting


### PR DESCRIPTION
Moving example-maven over to the buildsec repo.

Signed-off-by: Brandon Mitchell <git@bmitch.net>