### PR TITLE
Fix linting errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 labels: bug
 ---
+# Bug Report
 
 <!-- Provide a general summary of the issue in the title above. -->
 
@@ -72,7 +73,7 @@ echo "$OUTPUT" | tee >(pbcopy)
 
 -->
 
-```
+```txt
 (replace the example below with the script output)
 Last commit:
   d6d7647 Alternate approach for internal minikube OCI registry  (HEAD -> github-templates, upstream/main, upstream/HEAD, main)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,6 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 labels: enhancement
 ---
+# Feature Request
 
 <!-- Provide a general summary of the issue in the title above. -->
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,6 +3,7 @@ name: Question
 about: Need help? Ask away!
 labels: question
 ---
+# Question
 
 <!-- Provide a general summary of the issue in the title above. -->
 


### PR DESCRIPTION
These changes resolve linting errors which started appearing with `markdownlint-cli2@v0.5.0`

Signed-off-by: Brad Beck <bradley.beck@gmail.com>