### PR TITLE
Change introduction page to zola shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,4 @@
----
-title: "Factory for Repeatable Secure Creation of Artifacts"
-description:
-  "AdiDoks is a Zola theme helping you build modern documentation websites,
-  which is a port of the Hugo theme Doks for Zola."
-date: 2021-05-01T08:00:00+00:00
-updated: 2021-05-01T08:00:00+00:00
-draft: false
-weight: 10
-sort_by: "weight"
-template: "docs/page.html"
-
-extra:
-  toc: true
-  top: false
----
+# Factory for Repeatable Secure Creation of Artifacts (FRSCA)
 
 ## About The Project
 

--- a/docs/content/docs/getting-started/introduction.md
+++ b/docs/content/docs/getting-started/introduction.md
@@ -1,1 +1,17 @@
-../../../../README.md
+---
+title: "Factory for Repeatable Secure Creation of Artifacts (FRSCA)"
+description: "FRSCA is a secure build system"
+date: 2021-05-01T08:00:00+00:00
+updated: 2021-05-01T08:00:00+00:00
+draft: false
+weight: 10
+sort_by: "weight"
+template: "docs/page.html"
+
+extra:
+  toc: true
+  top: false
+  headerless: true
+---
+
+{{ markdown(value="../../../../README.md") }}

--- a/docs/templates/docs/page.html
+++ b/docs/templates/docs/page.html
@@ -1,0 +1,21 @@
+{% extends "adidoks/templates/docs/page.html" %}
+
+{% block content %}
+<div class="wrap container" role="document">
+  <div class="content">
+    <div class="row flex-xl-nowrap">
+	  {{ macros_sidebar::docs_sidebar(current_section=current_section) }}
+	  {{ macros_toc::docs_toc(page=page) }}
+      <main class="docs-content col-lg-11 col-xl-9">
+        {% if not page.extra.headerless %} <h1>{{ page.title }}</h1> {% endif %}
+        {% if page.extra.lead %}<p class="lead">{{ page.extra.lead | safe }}</p>{% endif %}
+        {{ page.content | safe }}
+        {% if config.extra.edit_page %}
+          {{ macros_edit_page::docs_edit_page(current_path=current_path) }}
+        {% endif %}
+        {{ macros_navigation::docs_navigation(page=page, current_section=current_section) }}
+      </main>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/docs/templates/shortcodes/markdown.html
+++ b/docs/templates/shortcodes/markdown.html
@@ -1,0 +1,2 @@
+{% set data = load_data(path=value) %}
+{{ data | markdown(inline=true) | safe}}


### PR DESCRIPTION
This allows us to inline the README.md and other markdown without
needing Zola headers. This is useful to be able to include the
README in the Zola docs while also keeping the README.md in GitHub
clean.

Signed-off-by: Michael Lieberman <mlieberman85@gmail.com>