### PR TITLE
Pull up ca-certs volumes

### DIFF
--- a/examples/cosign/task-ko.yaml
+++ b/examples/cosign/task-ko.yaml
@@ -54,12 +54,3 @@ spec:
           "$(params.SOURCE_SUBPATH)")
         echo -n "${KO_IMAGE}" | cut -d'@' -f1 | tr -d '[:space:]' | tee "$(results.IMAGE_URL.path)"
         echo -n "${KO_IMAGE}" | cut -d'@' -f2 | tr -d '[:space:]' | tee "$(results.IMAGE_DIGEST.path)"
-      volumeMounts:
-        - mountPath: /etc/ssl/certs/ca-certificates.crt
-          name: ca-certs
-          subPath: ca-certificates.crt
-          readOnly: true
-  volumes:
-    - configMap:
-        name: ca-certs
-      name: ca-certs

--- a/examples/examples.cue
+++ b/examples/examples.cue
@@ -61,6 +61,26 @@ frsca: configMap: "grype-config-map": {
 		"""
 }
 
+frsca: task: [_]: {
+	spec: {
+		volumes: [{
+			configMap: { name: "ca-certs" }
+			name: "ca-certs"
+		}]
+	}
+}
+
+frsca: task: [_]: {
+	spec: steps: [...{
+		volumeMounts: [{
+			mountPath: "/etc/ssl/certs/ca-certificates.crt"
+			name: "ca-certs"
+			subPath: "ca-certificates.crt"
+			readOnly: true
+		}]
+	}]
+}
+
 frsca: task: "grype-vulnerability-scan": {
 	spec: {
 		params: [{
@@ -101,22 +121,10 @@ frsca: task: "grype-vulnerability-scan": {
 			]
 			image: "anchore/grype:v0.35.0@sha256:857934a54874b7efe3d6964851ce54abb5a36d6200cdb62383990a5c7c8d748e"
 			name:  "grype-scanner"
-			volumeMounts: [{
-				mountPath: "/etc/ssl/certs/ca-certificates.crt"
-				name: "ca-certs"
-				subPath: "ca-certificates.crt"
-				readOnly: true
-			}]
 		}]
 		workspaces: [{
 			name: "grype-config"
 			mountPath: "/var/grype-config"
-		}]
-		volumes: [{
-      configMap: {
-        name: "ca-certs"
-			}
-      name: "ca-certs"
 		}]
 	}
 }

--- a/examples/sample-pipeline/sample-pipeline.cue
+++ b/examples/sample-pipeline/sample-pipeline.cue
@@ -226,9 +226,6 @@ frsca: task: "syft-bom-generator": {
 			env: [{
 				name:  "PIPELINE_DEBUG"
 				value: "$(params.pipeline-debug)"
-			}, {
-				name:  "DOCKER_CONFIG"
-				value: "/steps"
 			}]
 		}
 		steps: [{
@@ -241,15 +238,6 @@ frsca: task: "syft-bom-generator": {
 			]
 			image: "anchore/syft:v0.44.1@sha256:d5b44590062d4d9fc192455b5face4ebfd7879ec1540c939aa1766e5dcf4d5fc"
 			name:  "syft-bom-generator"
-			volumeMounts: [{
-				mountPath: "/steps"
-				name:      "steps-volume"
-			}, {
-				mountPath: "/etc/ssl/certs/ca-certificates.crt"
-				name: "ca-certs"
-				subPath: "ca-certificates.crt"
-				readOnly: true
-			}]
 		}, {
 			image: "gcr.io/projectsigstore/cosign:v1.8.0@sha256:12b4d428529654c95a7550a936cbb5c6fe93a046ea7454676cb6fb0ce566d78c"
 			name:  "attach-sbom"
@@ -260,24 +248,6 @@ frsca: task: "syft-bom-generator": {
 				"--type", "syft",
 				"$(params.image-ref)"
 			]
-			volumeMounts: [{
-				mountPath: "/steps"
-				name:      "steps-volume"
-			}, {
-				mountPath: "/etc/ssl/certs/ca-certificates.crt"
-				name: "ca-certs"
-				subPath: "ca-certificates.crt"
-				readOnly: true
-			}]
-		}]
-		volumes: [{
-			emptyDir: {}
-			name: "steps-volume"
-		}, {
-      configMap: {
-        name: "ca-certs"
-			}
-      name: "ca-certs"
 		}]
 		workspaces: [{
 			name: "source"


### PR DESCRIPTION
Pull the `ca-certs` volume configuration up into the top-level `example.cue`

Signed-off-by: Brad Beck <bradley.beck@gmail.com>