### PR TITLE
Bumping versions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: build
         uses: shalzz/zola-deploy-action@v0.14.1
         env:

--- a/.github/workflows/install-frsca.yaml
+++ b/.github/workflows/install-frsca.yaml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: mfinelli/setup-shfmt@v1
       - name: Lint all
         run: make lint
@@ -25,11 +25,11 @@ jobs:
       lint
     name: Test FRSCA Installation
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: "1.17.6"
+          go-version: "~1.19.0"
       - name: Vendor Dependencies
         run: |
           ./platform/vendor/vendor.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildsec/frsca
 
-go 1.17
+go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect


### PR DESCRIPTION
- Go 1.19 was released, which means 1.17 is no longer supported
- actions/checkout and actions/setup-go are v3 now

Signed-off-by: Brandon Mitchell <git@bmitch.net>