### PR TITLE
Make the image link relative

### DIFF
--- a/docs/content/docs/getting-started/architecture.md
+++ b/docs/content/docs/getting-started/architecture.md
@@ -16,7 +16,7 @@ top = false
 
 ## Diagram of Key Components
 
-![frsca-architecture](/img/frsca.png)
+![frsca-architecture](../../../img/frsca.png)
 
 ## Provisioning
 


### PR DESCRIPTION
Try as I might, I couldn't get the zola short codes and other suggestions to work that would use the base_url for an absolute path here. So I made it relative until someone can figure out a better solution. This fixes the broken image link on https://buildsec.github.io/frsca/docs/getting-started/architecture/

Signed-off-by: Brandon Mitchell <git@bmitch.net>