### PR TITLE
Update grype v0.35.0 -> v0.46.0

### DIFF
--- a/examples/examples.cue
+++ b/examples/examples.cue
@@ -119,7 +119,7 @@ frsca: task: "grype-vulnerability-scan": {
 				"--config",
 				"/var/grype-config/.grype.yaml"
 			]
-			image: "anchore/grype:v0.35.0@sha256:857934a54874b7efe3d6964851ce54abb5a36d6200cdb62383990a5c7c8d748e"
+			image: "anchore/grype:v0.46.0@sha256:6ccf6ac23f90fde7ea202ce2b18d6ad98d3e8992c73455841167afa27a71d93d"
 			name:  "grype-scanner"
 		}]
 		workspaces: [{


### PR DESCRIPTION
Update to the most recent version of grype. This resolves some false positives seen with the `cosign` example.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>