### PR TITLE
Improve support for internal registry

### DIFF
--- a/.github/workflows/install-frsca.yaml
+++ b/.github/workflows/install-frsca.yaml
@@ -42,10 +42,15 @@ jobs:
       - name: Try the cluster !
         run: kubectl get pods -A
       - name: Initialize FRSCA
+        env:
+          REGISTRY: "registry.registry"
         run: |
           make setup-frsca
       - name: Run buildpacks pipeline
+        env:
+          REGISTRY: "registry.registry"
         run: |
+          make registry-proxy >/dev/null &
           make example-buildpacks
           sleep 15
           tkn pr logs --last -f
@@ -54,13 +59,20 @@ jobs:
             exit 1
           fi
           sleep 60
-          export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-          docker run --rm gcr.io/go-containerregistry/crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
+          IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
+          if [ "${REGISTRY}" = "registry.registry" ]; then
+            IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+          fi
+          docker run --rm --net host gcr.io/go-containerregistry/crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
           tkn tr describe --last -o json | jq -r '.metadata.annotations["chains.tekton.dev/signed"]'
           cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
           cosign verify-attestation --type slsaprovenance --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
+          kill %?registry-proxy
       - name: Run sample pipeline to test kyverno
+        env:
+          REGISTRY: "registry.registry"
         run: |
+          make registry-proxy >/dev/null &
           make example-sample-pipeline
           sleep 15
           tkn pr logs --last -f
@@ -69,10 +81,14 @@ jobs:
             exit 1
           fi
           sleep 60
-          export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-          docker run --rm gcr.io/go-containerregistry/crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
+          IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
+          if [ "${REGISTRY}" = "registry.registry" ]; then
+            IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+          fi
+          docker run --rm --net host gcr.io/go-containerregistry/crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
 
           cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
           cosign verify-attestation --type slsaprovenance --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 
           kubectl wait --timeout=5m --for=condition=ready pods -l app=picalc -n prod
+          kill %?registry-proxy

--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -8,21 +8,14 @@ Execute the following commands from the root of this repository:
 # Only if a cluster is needed.
 make setup-minikube
 
+# Use the built-in registry, or replace with your own local registry
+export REGISTRY=registry.registry
+
 # Setup FRSCA environment
 make setup-frsca
 
-#### Begin local minikube registry
-##
-## Use this section if you want to use the minikube registry for
-## publishing OCI artifacts.
-##
-## In a separate terminal, port forward the registry: defaults to 0.0.0.0:5000
-#  make registry-proxy
-##
-## Set the registry for use in buildpacks.sh
-#  export REGISTRY=registry.registry
-##
-#### End local minikube registry
+# if using the built-in registry, run the proxy in the background or another window
+make registry-proxy >/dev/null &
 
 # Run a new pipeline.
 make example-buildpacks
@@ -40,7 +33,8 @@ tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/s
 IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
 TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 if [ "${REGISTRY}" = "registry.registry" ]; then
-  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+  : "${REGISTRY_PORT:=5000}"
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
@@ -51,8 +45,12 @@ cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 cosign verify-attestation --type slsaprovenance --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 
 # Verify the signature and attestation with tkn.
+# These commands do not work with the built in registry.
 tkn chain signature "${TASK_RUN}"
 tkn chain payload "${TASK_RUN}"
+
+# if the registry proxy is running in the background, it can be stopped
+kill %?registry-proxy
 ```
 
 ## Links

--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -37,11 +37,11 @@ tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/s
 # Should output "true"
 
 # Export the value of IMAGE_URL from the last pipeline run and the associated taskrun name:
-export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
-
-## If using the registry-proxy
-# export IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
+TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
+if [ "${REGISTRY}" = "registry.registry" ]; then
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
 crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"

--- a/examples/go-pipeline/README.md
+++ b/examples/go-pipeline/README.md
@@ -26,11 +26,11 @@ make example-golang-pipeline
 tkn pr logs --last -f
 
 # Export the value of IMAGE_URL from the last pipeline run and the associated taskrun name:
-export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
-
-## If using the registry-proxy
-# export IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
+TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
+if [ "${REGISTRY}" = "registry.registry" ]; then
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
 crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"

--- a/examples/go-pipeline/README.md
+++ b/examples/go-pipeline/README.md
@@ -16,8 +16,14 @@ auto determine the architecture.
 # Only if a cluster is needed.
 make setup-minikube
 
+# Use the built-in registry, or replace with your own local registry
+export REGISTRY=registry.registry
+
 # Setup FRSCA environment
 make setup-frsca
+
+# if using the built-in registry, run the proxy in the background or another window
+make registry-proxy >/dev/null &
 
 # Run a new pipeline.
 make example-golang-pipeline
@@ -29,7 +35,8 @@ tkn pr logs --last -f
 IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
 TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 if [ "${REGISTRY}" = "registry.registry" ]; then
-  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+  : "${REGISTRY_PORT:=5000}"
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
@@ -40,6 +47,10 @@ cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 cosign verify-attestation --type slsaprovenance --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 
 # Verify the signature and attestation with tkn.
+# These commands do not work with the built in registry.
 tkn chain signature "${TASK_RUN}"
 tkn chain payload "${TASK_RUN}"
+
+# if the registry proxy is running in the background, it can be stopped
+kill %?registry-proxy
 ```

--- a/examples/gradle-pipeline/README.md
+++ b/examples/gradle-pipeline/README.md
@@ -10,8 +10,14 @@ This is a sample Gradle tekton pipeline.
 # Only if a cluster is needed.
 make setup-minikube
 
+# Use the built-in registry, or replace with your own local registry
+export REGISTRY=registry.registry
+
 # Setup FRSCA environment
 make setup-frsca
+
+# if using the built-in registry, run the proxy in the background or another window
+make registry-proxy >/dev/null &
 
 # Run a new pipeline.
 make example-gradle-pipeline
@@ -23,7 +29,8 @@ tkn pr logs --last -f
 IMAGE_URL="$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')"
 TASK_RUN="$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')"
 if [ "${REGISTRY}" = "registry.registry" ]; then
-  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+  : "${REGISTRY_PORT:=5000}"
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
@@ -34,6 +41,10 @@ cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 cosign verify-attestation --type slsaprovenance --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 
 # Verify the signature and attestation with tkn.
+# These commands do not work with the built in registry.
 tkn chain signature "${TASK_RUN}"
 tkn chain payload "${TASK_RUN}"
+
+# if the registry proxy is running in the background, it can be stopped
+kill %?registry-proxy
 ```

--- a/examples/gradle-pipeline/README.md
+++ b/examples/gradle-pipeline/README.md
@@ -20,11 +20,11 @@ make example-gradle-pipeline
 tkn pr logs --last -f
 
 # Export the value of IMAGE_URL from the last pipeline run and the associated taskrun name:
-export IMAGE_URL="$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')"
-export TASK_RUN="$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')"
-
-## If using the registry-proxy
-# export IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+IMAGE_URL="$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')"
+TASK_RUN="$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')"
+if [ "${REGISTRY}" = "registry.registry" ]; then
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
 crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"

--- a/examples/ibm-tutorial/README.md
+++ b/examples/ibm-tutorial/README.md
@@ -6,21 +6,14 @@
 # Only if a cluster is needed.
 make setup-minikube
 
+# Use the built-in registry, or replace with your own local registry
+export REGISTRY=registry.registry
+
 # Setup FRSCA environment
 make setup-frsca
 
-#### Begin local minikube registry
-##
-## Use this section if you want to use the minikube registry for
-## publishing OCI artifacts.
-##
-## In a separate terminal, port forward the registry: defaults to 0.0.0.0:5000
-#  make registry-proxy
-##
-## Set the registry for use in buildpacks.sh
-#  export REGISTRY=registry.registry
-##
-#### End local minikube registry
+# if using the built-in registry, run the proxy in the background or another window
+make registry-proxy >/dev/null &
 
 # Run a new pipeline.
 make example-ibm-tutorial
@@ -37,9 +30,10 @@ tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/s
 # Export the value of IMAGE_URL from the last pipeline run and the associated taskrun name:
 export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
-
-## If using the registry-proxy
-# export IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+if [ "${REGISTRY}" = "registry.registry" ]; then
+  : "${REGISTRY_PORT:=5000}"
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
+fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
 crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
@@ -49,8 +43,12 @@ cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 cosign verify-attestation --type slsaprovenance --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
 
 # Verify the signature and attestation with tkn.
+# These commands do not work with the built in registry.
 tkn chain signature "${TASK_RUN}"
 tkn chain payload "${TASK_RUN}"
+
+# if the registry proxy is running in the background, it can be stopped
+kill %?registry-proxy
 ```
 
 ## Links

--- a/examples/sample-pipeline/README.md
+++ b/examples/sample-pipeline/README.md
@@ -26,11 +26,11 @@ make example-sample-pipeline
 tkn pr logs --last -f
 
 # Export the value of IMAGE_URL from the last taskrun and the taskrun name:
-export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
-
-## If using the registry-proxy
-# export IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
+TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
+if [ "${REGISTRY}" = "registry.registry" ]; then
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
 crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"

--- a/examples/sample-pipeline/README.md
+++ b/examples/sample-pipeline/README.md
@@ -16,8 +16,14 @@ application.
 # Only if a cluster is needed.
 make setup-minikube
 
+# Use the built-in registry, or replace with your own local registry
+export REGISTRY=registry.registry
+
 # Setup FRSCA environment
 make setup-frsca
+
+# if using the built-in registry, run the proxy in the background or another window
+make registry-proxy >/dev/null &
 
 # Run a new pipeline.
 make example-sample-pipeline
@@ -29,7 +35,8 @@ tkn pr logs --last -f
 IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
 TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 if [ "${REGISTRY}" = "registry.registry" ]; then
-  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
+  : "${REGISTRY_PORT:=5000}"
+  IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi
 
 # Double check that the attestation and the signature were uploaded to the OCI.
@@ -43,8 +50,12 @@ cosign verify-attestation --type slsaprovenance --key k8s://tekton-chains/signin
 cosign download sbom "${IMAGE_URL}"
 
 # Verify the signature and attestation with tkn.
+# These commands do not work with the built in registry.
 tkn chain signature "${TASK_RUN}"
 tkn chain payload "${TASK_RUN}"
+
+# if the registry proxy is running in the background, it can be stopped
+kill %?registry-proxy
 ```
 
 Once successfully completed. You should be able to see your application deployed

--- a/examples/sample-pipeline/sample-pipeline.cue
+++ b/examples/sample-pipeline/sample-pipeline.cue
@@ -201,6 +201,8 @@ frsca: task: "deploy-using-kubectl": {
 				"s;__IMAGE__;$(params.image);g",
 				"-e",
 				"s;__DIGEST__;$(params.imageDigest);g",
+				"-e",
+				"s;registry.registry/;localhost:5000/;g",
 				"$(workspaces.git-source.path)/$(params.pathToYamlFile)",
 			]
 			command: [


### PR DESCRIPTION
This updates the readme to be easier to copy/paste for those using a local registry, updates CI to test using the local registry, and updates the prod deploy to use the localhost:5000 name in the image since that is run outside of the CNI.

Signed-off-by: Brandon Mitchell <git@bmitch.net>