### PR TITLE
Stop using deprecated flag `service-account-api-audiences`

### DIFF
--- a/platform/00-kubernetes-minikube-setup.sh
+++ b/platform/00-kubernetes-minikube-setup.sh
@@ -202,7 +202,7 @@ else
     --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key \
     --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub \
     --extra-config=apiserver.service-account-issuer=api \
-    --extra-config=apiserver.service-account-api-audiences=api,spire-server \
+    --extra-config=apiserver.api-audiences=api,spire-server \
     --extra-config=apiserver.authorization-mode=Node,RBAC \
     --memory max
 fi


### PR DESCRIPTION
For the API server, `—service-account-api-audiences` has been deprecated since v1.13. It is fully removed in v1.25.

This changes switich to using the suggest flag `—api-audiences`

Signed-off-by: Brad Beck <bradley.beck@gmail.com>