### PR TITLE
Update kaniko v0.6 hash

### DIFF
--- a/platform/vendor/tekton/catalog/main/task/kaniko/0.6/kaniko.yaml
+++ b/platform/vendor/tekton/catalog/main/task/kaniko/0.6/kaniko.yaml
@@ -9,7 +9,7 @@ metadata:
     tekton.dev/categories: Image Build
     tekton.dev/tags: image-build
     tekton.dev/displayName: "Build and upload container image using Kaniko"
-    tekton.dev/platforms: "linux/amd64"
+    tekton.dev/platforms: "linux/amd64,linux/arm64,linux/ppc64le"
 spec:
   description: >-
     This Task builds a simple Dockerfile with kaniko and pushes to a registry.
@@ -58,7 +58,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: write-url
-      image: docker.io/library/bash:5.1.4@sha256:b208215a4655538be652b2769d82e576bc4d0a2bb132144c060efc5be8c3f5d6
+      image: docker.io/library/bash:5.1.4@sha256:c523c636b722339f41b6a431b44588ab2f762c5de5ec3bd7964420ff982fb1d9
       script: |
         set -e
         image="$(params.IMAGE)"

--- a/platform/vendor/vendor.yaml
+++ b/platform/vendor/vendor.yaml
@@ -35,7 +35,7 @@ files:
     validation_type: "sha256"
   - release_file: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.6/kaniko.yaml"
     destination_dir: "tekton/catalog/main/task/kaniko/0.6"
-    sha256: "595746871b33eb6dc84b56b1a94365d8707cbe7fcec91fb02218be834dce504c"
+    sha256: "e3c6bd5b59be748d43657edee38626801d2ffb59cf4adc0e15a7a88a75bb6872"
     validation_type: "sha256"
   - release_file: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildpacks/0.5/buildpacks.yaml"
     destination_dir: "tekton/catalog/main/task/buildpacks/0.5"


### PR DESCRIPTION
Update the sha256 hash for kaniko v0.6.

It changed because of an update to the Tekton catalog (https://github.com/tektoncd/catalog/pull/1071)

Signed-off-by: Brad Beck <bradley.beck@gmail.com>