### PR TITLE
Use the syft multi-platform image digest

### DIFF
--- a/examples/sample-pipeline/sample-pipeline.cue
+++ b/examples/sample-pipeline/sample-pipeline.cue
@@ -269,7 +269,7 @@ frsca: task: "syft-bom-generator": {
 				"$(workspaces.source.path)/$(params.sbom-filepath)",
 				"$(params.image-ref)",
 			]
-			image: "anchore/syft:v0.58.0@sha256:46f909ad6f296606893fd6f21d079bb78e7c6e45487f233b9ae4cfdd958ef457"
+			image: "anchore/syft:v0.58.0@sha256:b764278a9a45f3493b78b8708a4d68447807397fe8c8f59bf21f18c9bee4be94"
 			name:  "syft-bom-generator"
 		}, {
 			image: "gcr.io/projectsigstore/cosign:v1.12.0@sha256:880cc3ec8088fa59a43025d4f20961e8abc7c732e276a211cfb8b66793455dd0"


### PR DESCRIPTION
`sha256:46f...` is the digest for the linux/amd64 image, switching to the multi-platform digest:

```
$ regctl manifest get anchore/syft:v0.58.0
Name:        anchore/syft:v0.58.0
MediaType:   application/vnd.docker.distribution.manifest.list.v2+json
Digest:      sha256:b764278a9a45f3493b78b8708a4d68447807397fe8c8f59bf21f18c9bee4be94
             
Manifests:   
             
  Name:      docker.io/anchore/syft:v0.58.0@sha256:46f909ad6f296606893fd6f21d079bb78e7c6e45487f233b9ae4cfdd958ef457
  Digest:    sha256:46f909ad6f296606893fd6f21d079bb78e7c6e45487f233b9ae4cfdd958ef457
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/amd64
             
  Name:      docker.io/anchore/syft:v0.58.0@sha256:9991528e5791d08d309bf0d378d2487122b1599ac88f48fcd25808753383128c
  Digest:    sha256:9991528e5791d08d309bf0d378d2487122b1599ac88f48fcd25808753383128c
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/arm64
             
  Name:      docker.io/anchore/syft:v0.58.0@sha256:806bf0e9cef3a471ddc7e6ea71ac89f92c3ffdbfd37ca2eb46c7839049fcbe76
  Digest:    sha256:806bf0e9cef3a471ddc7e6ea71ac89f92c3ffdbfd37ca2eb46c7839049fcbe76
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/ppc64le
             
  Name:      docker.io/anchore/syft:v0.58.0@sha256:6b80919e4be645d359a81a61ff6edb9636d752b0beb2c72c864cc0bff561aa13
  Digest:    sha256:6b80919e4be645d359a81a61ff6edb9636d752b0beb2c72c864cc0bff561aa13
  MediaType: application/vnd.docker.distribution.manifest.v2+json
  Platform:  linux/s390x
```

Signed-off-by: Brandon Mitchell <git@bmitch.net>