### PR TITLE
Update provenance.sh for cosign 1.5.1+

### DIFF
--- a/scripts/provenance.sh
+++ b/scripts/provenance.sh
@@ -9,15 +9,7 @@ else
 fi
 
 TASKRUN_UID=$(kubectl get taskrun "$TASKRUN" -o=json | jq -r '.metadata.uid')
-TASKRUN_JSON="$TASKRUN.json"
-kubectl get taskrun "$TASKRUN" -o=json | jq > "$TASKRUN_JSON"
-jq \
-  -r ".metadata.annotations[\"chains.tekton.dev/payload-taskrun-$TASKRUN_UID\"]" \
-  "$TASKRUN_JSON"  \
-  | base64 --decode > payload.json
-jq \
-  -r ".metadata.annotations[\"chains.tekton.dev/signature-taskrun-$TASKRUN_UID\"]" \
-  "$TASKRUN_JSON" > signature.pub
+kubectl get taskrun "$TASKRUN" -o=json | jq -r ".metadata.annotations[\"chains.tekton.dev/signature-taskrun-$TASKRUN_UID\"]" | base64 --decode > signature.pub
 
 echo "Verifying signature with cosign..."
-cosign verify-blob -key cosign.pub -signature ./signature.pub ./payload.json
+cosign verify-blob --key k8s://tekton-chains/signing-secrets --signature ./signature.pub ./signature.pub


### PR DESCRIPTION
Update provenance.sh to work with a more recent version of cosign (1.5.1+)

Signed-off-by: Brad Beck <bradley.beck@gmail.com>