### PR TITLE
Upgrade Spire to use CSI driver

### DIFF
--- a/platform/components/spire/values.yaml
+++ b/platform/components/spire/values.yaml
@@ -5,6 +5,9 @@ server:
 agent:
   kubeletSkipVerification: true
 
+csi:
+  enabled: true
+
 client:
   enabled: false
 

--- a/platform/components/tekton/chains/patch_spire.json
+++ b/platform/components/tekton/chains/patch_spire.json
@@ -42,9 +42,9 @@
         ],
         "volumes": [
           {
-            "hostPath": {
-              "path": "/run/spire/sockets",
-              "type": "DirectoryOrCreate"
+            "csi": {
+              "driver": "csi.spiffe.io",
+              "readOnly": true
             },
             "name": "spire-agent-socket"
           }

--- a/platform/vendor/spire/chart/Chart.yaml
+++ b/platform/vendor/spire/chart/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 1.16.0
 description: A Helm chart for Kubernetes
 name: spire
 type: application
-version: 0.0.5
+version: 0.1.2

--- a/platform/vendor/spire/chart/templates/agent-configmap.yaml
+++ b/platform/vendor/spire/chart/templates/agent-configmap.yaml
@@ -11,7 +11,7 @@ data:
       log_level = "DEBUG"
       server_address = "{{ include "spire.fullname" . }}-server"
       server_port = "8081"
-      # socket_path = "/run/spire/sockets/agent.sock"
+      socket_path = "{{ .Values.agent.sockDir }}/{{ .Values.agent.sockName }}"
       trust_bundle_path = "/run/spire/bundle/bundle.crt"
       trust_domain = "{{ index .Values.server.trustDomain }}"
     }

--- a/platform/vendor/spire/chart/templates/agent-daemonset.yaml
+++ b/platform/vendor/spire/chart/templates/agent-daemonset.yaml
@@ -37,7 +37,7 @@ spec:
           # This is a small image with wait-for-it, choose whatever image
           # you prefer that waits for a service to be up. This image is built
           # from https://github.com/lqhl/wait-for-it
-          image: {{ .Values.image.repository }}/wait-for-it
+          image: {{ .Values.image.waitForIt }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["-t", "30", "{{ include "spire.fullname" . }}-server:{{ .Values.service.server.port }}"]
       containers:
@@ -54,7 +54,7 @@ spec:
             - name: spire-bundle
               mountPath: /run/spire/bundle
             - name: spire-agent-socket
-              mountPath: /tmp/spire-agent/public
+              mountPath: {{ .Values.agent.sockDir }}
               readOnly: false
             - name: spire-token
               mountPath: /var/run/secrets/tokens
@@ -74,6 +74,57 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources.agent | nindent 12 }}
+        {{- if .Values.csi.enabled }}
+        # This is the container which runs the SPIFFE CSI driver.
+        - name: spiffe-csi-driver
+          image: {{ .Values.image.repository }}/spiffe-csi-driver:{{ .Values.image.tagCSI }}
+          imagePullPolicy: IfNotPresent
+          args: [
+            "-workload-api-socket-dir", "{{ .Values.agent.sockDir }}",
+            "-csi-socket-path", "/run/spiffe-csi/csi.sock",
+          ]
+          env:
+            # The CSI driver needs a unique node ID. The node name can be
+            # used for this purpose.
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            # The volume containing the SPIRE agent socket. The SPIFFE CSI
+            # driver will mount this directory into containers.
+            - name: spire-agent-socket
+              mountPath: {{ .Values.agent.sockDir }}
+              readOnly: true
+            # The volume that will contain the CSI driver socket shared
+            # with the kubelet and the driver registrar.
+            - name: spire-csi-socket-dir
+              mountPath: /run/spiffe-csi
+            # The volume containing mount points for containers.
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+          securityContext:
+            privileged: true
+        # This container runs the CSI Node Driver Registrar which takes care
+        # of all the little details required to register a CSI driver with
+        # the kubelet.
+        - name: node-driver-registrar
+          image: {{ .Values.image.csiRegistrar }}
+          imagePullPolicy: IfNotPresent
+          args: [
+            "-csi-address", "/run/spiffe-csi/csi.sock",
+            "-kubelet-registration-path", "/var/lib/kubelet/plugins/csi.spiffe.io/csi.sock",
+          ]
+          volumeMounts:
+            # The registrar needs access to the SPIFFE CSI driver socket
+            - name: spire-csi-socket-dir
+              mountPath: /run/spiffe-csi
+            # The registrar needs access to the Kubelet plugin registration
+            # directory
+            - name: kubelet-plugin-registration-dir
+              mountPath: /registration
+        {{- end }}
       volumes:
         - name: spire-config
           configMap:
@@ -81,10 +132,6 @@ spec:
         - name: spire-bundle
           configMap:
             name: {{ include "spire.fullname" . }}-bundle
-        - name: spire-agent-socket
-          hostPath:
-            path: /run/spire/sockets
-            type: DirectoryOrCreate
         - name: spire-token
           projected:
             sources:
@@ -92,6 +139,35 @@ spec:
                 path: spire-agent
                 expirationSeconds: 7200
                 audience: spire-server
+        # This volume is used to share the Workload API socket between the CSI
+        # driver and SPIRE agent. Note, an emptyDir volume could also be used,
+        # however, this can lead to broken bind mounts in the workload
+        # containers if the agent pod is restarted (since the emptyDir
+        # directory on the node that was mounted into workload containers by
+        # the CSI driver belongs to the old pod instance and is no longer
+        # valid).
+        - name: spire-agent-socket
+          hostPath:
+            path: {{ .Values.agent.hostDir }}
+            type: DirectoryOrCreate
+        {{- if .Values.csi.enabled }}
+        # This volume is where the socket for kubelet->driver communication lives
+        - name: spire-csi-socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.spiffe.io
+            type: DirectoryOrCreate
+        # This volume is where the SPIFFE CSI driver mounts volumes
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: Directory
+        # This volume is where the node-driver-registrar registers the plugin
+        # with kubelet
+        - name: kubelet-plugin-registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/platform/vendor/spire/chart/templates/server-configmap.yaml
+++ b/platform/vendor/spire/chart/templates/server-configmap.yaml
@@ -9,7 +9,7 @@ data:
     server {
       bind_address = "0.0.0.0"
       bind_port = "8081"
-      # socket_path = "/run/spire/sockets/server.sock"
+      socket_path = "{{ .Values.server.sockDir }}/{{ .Values.server.sockName }}"
       trust_domain = "{{ .Values.server.trustDomain }}"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"

--- a/platform/vendor/spire/chart/templates/server-statefulset.yaml
+++ b/platform/vendor/spire/chart/templates/server-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
               mountPath: /run/spire/data
               readOnly: false
             - name: spire-server-socket
-              mountPath: /tmp/spire-server/private
+              mountPath: {{ .Values.server.sockDir }}
               readOnly: false
           livenessProbe:
             httpGet:
@@ -70,7 +70,7 @@ spec:
             {{- toYaml .Values.resources.server | nindent 12 }}
         {{- if .Values.oidc.enabled }}
         - name: spire-oidc
-          image: {{ .Values.image.repository }}/oidc-discovery-provider:{{ .Values.image.tag }}
+          image: {{ .Values.image.repository }}/spire-oidc-provider:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -config
@@ -81,7 +81,7 @@ spec:
             protocol: TCP
           volumeMounts:
           - name: spire-server-socket
-            mountPath: /tmp/spire-server/private
+            mountPath: {{ .Values.server.sockDir }}
             readOnly: false
           - name: spire-oidc-config
             mountPath: /run/spire/oidc/config/
@@ -89,9 +89,18 @@ spec:
           - name: spire-data
             mountPath: /run/spire/data
             readOnly: false
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8080
+            failureThreshold: 2
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/bin/ps", "aux", " ||", "grep", "oidc-discovery-provider -config /run/spire/oidc/config/oidc-discovery-provider.conf"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
           resources:
@@ -109,7 +118,7 @@ spec:
             protocol: TCP
           volumeMounts:
           - name: spire-server-socket
-            mountPath: /tmp/spire-server/private
+            mountPath: {{ .Values.server.sockDir }}
             readOnly: true
           - name: spire-oidc-nginx-config
             mountPath: /etc/nginx/conf.d/

--- a/platform/vendor/spire/chart/templates/spiffe-csi-driver.yaml
+++ b/platform/vendor/spire/chart/templates/spiffe-csi-driver.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.csi.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: "csi.spiffe.io"
+spec:
+  # Only ephemeral, inline volumes are supported. There is no need for a
+  # controller to provision and attach volumes.
+  attachRequired: false
+
+  # Request the pod information which the CSI driver uses to verify that an
+  # ephemeral mount was requested.
+  podInfoOnMount: true
+
+  # Don't change ownership on the contents of the mount since the Workload API
+  # Unix Domain Socket is typically open to all (i.e. 0777).
+  fsGroupPolicy: None
+
+  # Declare support for ephemeral volumes only.
+  volumeLifecycleModes:
+    - Ephemeral
+---
+{{- end }}

--- a/platform/vendor/spire/chart/values.yaml
+++ b/platform/vendor/spire/chart/values.yaml
@@ -6,9 +6,12 @@
 replicaCount: 1
 
 image:
-  repository: gcr.io/spiffe-io
+  repository: ghcr.io/spiffe
   pullPolicy: IfNotPresent
-  tag: "1.0.2"
+  tag: "1.4.4"
+  tagCSI: "0.2.0" # csi driver version
+  waitForIt: "gcr.io/spiffe-io/wait-for-it"
+  csiRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v2.0.1"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -17,10 +20,15 @@ fullnameOverride: ""
 server:
   trustDomain: example.org
   clusterName: demo-cluster
+  sockDir: "/tmp/spire-server/private"
+  sockName: "api.sock"
 
 agent:
   # verification should be disabled in some environments, including Minikube
   kubeletSkipVerification: false
+  hostDir: "/run/spire/sockets"
+  sockDir: "/tmp/spire-agent/public"
+  sockName: "api.sock" # use api.sock for backwards compatibility
 
 oidc:
   enabled: false
@@ -32,6 +40,9 @@ oidc:
   certsSecret: ""
 
 client:
+  enabled: false
+
+csi:
   enabled: false
 
 serviceAccount:

--- a/platform/vendor/vendor-helm-all.sh
+++ b/platform/vendor/vendor-helm-all.sh
@@ -9,7 +9,7 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 
 cd "$GIT_ROOT/platform/vendor"
 
-./vendor-helm-chart.sh "$@" -d ./spire/chart       -c spire          -v 0.0.5   -r https://sudo-bmitch.github.io/helm-charts
+./vendor-helm-chart.sh "$@" -d ./spire/chart       -c spire          -v 0.1.2   -r https://sudo-bmitch.github.io/helm-charts
 ./vendor-helm-chart.sh "$@" -d ./vault/chart       -c vault          -v 0.20.0  -r https://helm.releases.hashicorp.com
 ./vendor-helm-chart.sh "$@" -d ./gatekeeper/chart  -c gatekeeper     -v 3.6.0   -r https://open-policy-agent.github.io/gatekeeper/charts
 ./vendor-helm-chart.sh "$@" -d ./elastic/chart     -c elasticsearch  -v 7.17.3  -r https://helm.elastic.co


### PR DESCRIPTION
This bumps up the Spire helm chart for the latest release, and the helm chart also adds support for the CSI driver so that workloads no longer need to perform a hostPath mount. The chains patch was updated to use the driver.

Fixes #130, replaces #354

Signed-off-by: Brandon Mitchell <git@bmitch.net>