### PR TITLE
chains controller needs to be scaled down and up

### DIFF
--- a/platform/13-tekton-chains-setup.sh
+++ b/platform/13-tekton-chains-setup.sh
@@ -31,7 +31,7 @@ kubectl patch \
       -n tekton-chains \
       --patch-file "$GIT_ROOT"/platform/components/tekton/chains/patch_ca_certs.json
 
-kubectl scale deployment -n tekton-chains tekton-chains-controller --replicas=0
-kubectl scale deployment -n tekton-chains tekton-chains-controller --replicas=1
+# restart tekton chains controller for patched configmap
+kubectl rollout restart -n tekton-chains deployment/tekton-chains-controller
 
 kubectl rollout status -n tekton-chains deployment/tekton-chains-controller

--- a/platform/13-tekton-chains-setup.sh
+++ b/platform/13-tekton-chains-setup.sh
@@ -31,4 +31,7 @@ kubectl patch \
       -n tekton-chains \
       --patch-file "$GIT_ROOT"/platform/components/tekton/chains/patch_ca_certs.json
 
+kubectl scale deployment -n tekton-chains tekton-chains-controller --replicas=0
+kubectl scale deployment -n tekton-chains tekton-chains-controller --replicas=1
+
 kubectl rollout status -n tekton-chains deployment/tekton-chains-controller


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Chains controller needs to be scaled down and up in order for the `chains-config` configMap to be active. This fixes the issue of two attestation being push to OCI by chains.