### PR TITLE
Update buildType in ClusterPolicy

### DIFF
--- a/resources/kyverno/admission-control-policy/admission-control-verify-attestation.cue
+++ b/resources/kyverno/admission-control-policy/admission-control-verify-attestation.cue
@@ -14,7 +14,7 @@ frsca: clusterPolicy: "attest-code-review": {
 					}, {
 						key:      "{{ buildType }}"
 						operator: "Equals"
-						value:    "https://tekton.dev/attestations/chains@v2"
+						value:    "tekton.dev/v1beta1/TaskRun"
 					}]
 				}]
 			}]


### PR DESCRIPTION
Recent versions of Chains are now using `tekton.dev/v1beta1/TaskRun` instead of `https://tekton.dev/attestations/chains@v2` as the `buildType` in the SLSA attestation.

This PR updates the Kyverno `ClusterPolicy` for the public repository where built images are pushed.

Fixes: https://github.com/buildsec/frsca/issues/372

Signed-off-by: Brad Beck <bradley.beck@gmail.com>