### PR TITLE
Fix vendor hash of git-clone task

### DIFF
--- a/platform/vendor/tekton/catalog/main/task/git-clone/0.9/git-clone.yaml
+++ b/platform/vendor/tekton/catalog/main/task/git-clone/0.9/git-clone.yaml
@@ -113,6 +113,8 @@ spec:
       description: The precise commit SHA that was fetched by this Task.
     - name: url
       description: The precise URL that was fetched by this Task.
+    - name: committer-date
+      description: The epoch timestamp of the commit that was fetched by this Task.
   steps:
     - name: clone
       image: "$(params.gitInitImage)"
@@ -234,5 +236,7 @@ spec:
         if [ "${EXIT_CODE}" != 0 ] ; then
           exit "${EXIT_CODE}"
         fi
+        RESULT_COMMITTER_DATE="$(git log -1 --pretty=%ct)"
+        printf "%s" "${RESULT_COMMITTER_DATE}" > "$(results.committer-date.path)"
         printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
         printf "%s" "${PARAM_URL}" > "$(results.url.path)"

--- a/platform/vendor/vendor.yaml
+++ b/platform/vendor/vendor.yaml
@@ -38,7 +38,7 @@ files:
     validation_type: "sha256"
   - release_file: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.9/git-clone.yaml"
     destination_dir: "tekton/catalog/main/task/git-clone/0.9"
-    sha256: "a42b8043562ad7326d92dd84a3becebbbaa9fa49d398980dad1f6dd81259e98e"
+    sha256: "ca4c32bcfe52c1975088d77c69e4b0540fdac68dc5a10a17ab963a349101bb7e"
     validation_type: "sha256"
   - release_file: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-build/0.3/golang-build.yaml"
     destination_dir: "tekton/catalog/main/task/golang-build/0.3"


### PR DESCRIPTION
The `git-clone` task was updated in place which resulted in a change in the hash. (see https://github.com/tektoncd/catalog/pull/1123)

This PR updates the YAML and the hash used by vendorme.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>