### PR TITLE
Update git-clone sha256

### DIFF
--- a/platform/vendor/tekton/catalog/main/task/git-clone/0.9/git-clone.yaml
+++ b/platform/vendor/tekton/catalog/main/task/git-clone/0.9/git-clone.yaml
@@ -213,7 +213,7 @@ spec:
         }
 
         if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
-          cleandir
+          cleandir || true
         fi
 
         test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"

--- a/platform/vendor/vendor.yaml
+++ b/platform/vendor/vendor.yaml
@@ -38,7 +38,7 @@ files:
     validation_type: "sha256"
   - release_file: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.9/git-clone.yaml"
     destination_dir: "tekton/catalog/main/task/git-clone/0.9"
-    sha256: "ca4c32bcfe52c1975088d77c69e4b0540fdac68dc5a10a17ab963a349101bb7e"
+    sha256: "d4d59da1eeef1207f9b04e319ae095f08bf618815104905f8fcebbdb6f99c1ac"
     validation_type: "sha256"
   - release_file: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-build/0.3/golang-build.yaml"
     destination_dir: "tekton/catalog/main/task/golang-build/0.3"


### PR DESCRIPTION
The git-clone task was updated in place. This PR updates the sha256 used by vendorme.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>