### PR TITLE
Workaround for git dubious ownership error

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3.3.0
+      - name: Workaround for detected dubious ownership
+        run: git config --global --add safe.directory /github/workspace
       - name: build
         uses: shalzz/zola-deploy-action@4e8cfaf04f68aef5146e33319e4e3e8e9b26e2c0  # v0.16.1
         env:


### PR DESCRIPTION
Workaround for the following error in the docs workflow:

```
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

Signed-off-by: Brad Beck <bradley.beck@gmail.com>