### PR TITLE
Adjust Markdown Linting Tasks

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 ---
 title: "How to Contribute"
-description: "Contribute to the Factory for Repeatable Secure Creation of Artifacts."
+description:
+  "Contribute to the Factory for Repeatable Secure Creation of Artifacts."
 date: 2021-11-25T18:10:00+00:00
 updated: 2021-11-25T18:10:00+00:00
 draft: false
@@ -13,8 +14,7 @@ The FRSCA project welcomes any kind of contributions, from code to documentation
 via fixing typos. Please feel free to raise an [issue] if you would like to work
 on something major to ensure efficient collaboration and avoid duplicate effort.
 
-The code lives in the
-[frsca repository](https://github.com/buildsec/frsca).
+The code lives in the [frsca repository](https://github.com/buildsec/frsca).
 
 ## Guidelines
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 labels: bug
 ---
+
 # Bug Report
 
 <!-- Provide a general summary of the issue in the title above. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,6 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 labels: enhancement
 ---
+
 # Feature Request
 
 <!-- Provide a general summary of the issue in the title above. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,6 +3,7 @@ name: Question
 about: Need help? Ask away!
 labels: question
 ---
+
 # Question
 
 <!-- Provide a general summary of the issue in the title above. -->

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
-docs/themes
+/docs/themes
+/platform

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,8 +9,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -20,23 +20,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -63,8 +63,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-conduct@openssf.org.
-All complaints will be reviewed and investigated promptly and fairly.
+conduct@openssf.org. All complaints will be reviewed and investigated promptly
+and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
@@ -85,15 +85,15 @@ behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
 **Consequence**: A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
@@ -109,11 +109,11 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
@@ -121,8 +121,8 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ lint: lint-md lint-yaml lint-shell ## Run all linters
 
 .PHONY: lint-md
 lint-md: ## Lint markdown files
-	npx --yes markdownlint-cli2  "**/*.md" "#docs/themes" "#platform/vendor"
+	npx --yes markdownlint-cli2  "**/*.md" "#docs/themes" "#platform/"
 
 .PHONY: lint-shell
 lint-shell: ## Lint shell files

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## About The Project
 
-Factory for Repeatable Secure Creation of Artifacts (aka FRSCA pronounced Fresca)
-aims to help secure the supply chain by securing build pipelines.
+Factory for Repeatable Secure Creation of Artifacts (aka FRSCA pronounced
+Fresca) aims to help secure the supply chain by securing build pipelines.
 
 It achieves its goals by being 2 things:
 
@@ -27,15 +27,16 @@ At its core FRSCA uses these projects to achieve its goals:
 - [Helm] and [CUE] - For provisioning kubernetes resources
 - [CUE] - For secure pipeline abstractions and definitions
 
-See: [Architecture Docs](https://buildsec.github.io/frsca/docs/getting-started/architecture/)
+See:
+[Architecture Docs](https://buildsec.github.io/frsca/docs/getting-started/architecture/)
 for more info
 
 FRSCA is also an implementation of the CNCF's
 [Secure Software Factory Reference Architecture](https://github.com/cncf/tag-security/blob/main/supply-chain-security/secure-software-factory/Secure_Software_Factory_Whitepaper.pdf)
 which is based on the CNCF's
 [Software Supply Chain Best Practices White Paper](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/CNCF_SSCP_v1.pdf).
-It is also intended to follow [SLSA](https://slsa.dev) requirements closely
-and generate in-toto attesttations for SLSA provenance predicates.
+It is also intended to follow [SLSA](https://slsa.dev) requirements closely and
+generate in-toto attesttations for SLSA provenance predicates.
 
 _NOTE_: FRSCA is under very active development. A lot will change, it isn't
 production ready yet.
@@ -57,7 +58,8 @@ This will perform the following actions:
 
 1. Install and setup minikube, and supporting cli tools, like `cosign` and `jq`
    if they are not already installed.
-1. Install development tooling to simulate a production environment, which includes:
+1. Install development tooling to simulate a production environment, which
+   includes:
    1. [Cert-manager]
    1. [registry]
    1. [SPIFFE/Spire]
@@ -68,7 +70,8 @@ This will perform the following actions:
    1. [Kyverno]
 1. Setup a mirror of example repositories and tekton triggers for each mirror.
 
-Once FRSCA has been installed you can follow the various examples under `/examples`.
+Once FRSCA has been installed you can follow the various examples under
+`/examples`.
 
 Tearing down the Minikube cluster generated in the quickstart, simply run:
 
@@ -78,8 +81,7 @@ make teardown
 
 ## Going further
 
-The full documentation is available at
-<https://buildsec.github.io/frsca/>
+The full documentation is available at <https://buildsec.github.io/frsca/>
 
 ## Community
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
 # FRSCA Diagrams
 
-The diagrams in this directory are written in the structurizr language. In
-order to view them or export them as images see: [Structurizr documentation](https://structurizr.org/)
+The diagrams in this directory are written in the structurizr language. In order
+to view them or export them as images see:
+[Structurizr documentation](https://structurizr.org/)

--- a/docs/content/docs/help/using-cue.md
+++ b/docs/content/docs/help/using-cue.md
@@ -14,9 +14,9 @@ top = false
 
 ## CUE Module Structure
 
-The top level of Factory for Repeatable Secure Creation of Artifacts (FRSCA)
-is structured as a
-[CUE module](https://cuelang.org/docs/concepts/packages/) and follows the
+The top level of Factory for Repeatable Secure Creation of Artifacts (FRSCA) is
+structured as a [CUE module](https://cuelang.org/docs/concepts/packages/) and
+follows the
 [schema/policy/data](https://cuelang.org/docs/concepts/packages/#file-organization)
 pattern for organizing the files.
 
@@ -25,8 +25,8 @@ The
 directory is predominantly for CUE package management. All of the files in
 `cue.mod/gen/...` are generated from the `cue get go ...` command importing go
 modules and converting them to CUE. These can then be imported and used to
-verify the structure of things such as `ConfigMap`. `frsca.cue` imports several of
-these and creates base structures based on these imported go structs.
+verify the structure of things such as `ConfigMap`. `frsca.cue` imports several
+of these and creates base structures based on these imported go structs.
 
 For the most part, CUE expects the evaluation to be done relative to the root of
 the CUE module. Evaluation can be narrowed by providing a path to a subdirectory

--- a/examples/cosign/README.md
+++ b/examples/cosign/README.md
@@ -56,8 +56,8 @@ kill %?registry-proxy
 
 ### SBOM
 
-Based on the [CycloneDX documentation](https://cyclonedx.org/use-cases/),
-there is a lot you can do with it! Let's see in practice how it is.
+Based on the [CycloneDX documentation](https://cyclonedx.org/use-cases/), there
+is a lot you can do with it! Let's see in practice how it is.
 
 Start by cloning the [cosign] repository:
 
@@ -97,26 +97,27 @@ Generate the SBOM with [cyclonedx-gomod] from the [cosign] source repository:
 
 ##### Known vulnerabilities
 
-* CPE
-  * Online search: <https://nvd.nist.gov/products/cpe/search>
-* SWID
-  * Java CLI tool: <https://csrc.nist.gov/Projects/Software-Identification-SWID/resources>
-* Use Package URL ([PURL](<https://github.com/package-url/purl-spec>)) standard
-  to identify and locate dependencies.
+- CPE
+  - Online search: <https://nvd.nist.gov/products/cpe/search>
+- SWID
+  - Java CLI tool:
+    <https://csrc.nist.gov/Projects/Software-Identification-SWID/resources>
+- Use Package URL ([PURL](https://github.com/package-url/purl-spec)) standard to
+  identify and locate dependencies.
 
 ##### Integrity verification
 
-* No tool to verify the integrity automatically
+- No tool to verify the integrity automatically
 
 ##### Authenticity
 
-* No tool to validate signature(s). There should be something similar to what
-[cosign] does with the DSS envelopes.
+- No tool to validate signature(s). There should be something similar to what
+  [cosign] does with the DSS envelopes.
 
 ##### Package evaluation
 
-* Uses PURL
-* Seems interesting but I am not so sure what to do with it
+- Uses PURL
+- Seems interesting but I am not so sure what to do with it
 
 ##### License compliance
 
@@ -126,25 +127,25 @@ List the licenses found in the SBOM:
 jq '.components[].evidence.licenses[]?.license.id' cyclonedx.sbom |sort -u
 ```
 
-* No licenses are simply shown as a blank line.
-* No tool to validate the licenses against <https://spdx.org/licenses/>.
-* No tool to validate licenses against company policy.
-* If a dependency has no license, it appears only on the CLI tool output.
+- No licenses are simply shown as a blank line.
+- No tool to validate the licenses against <https://spdx.org/licenses/>.
+- No tool to validate licenses against company policy.
+- If a dependency has no license, it appears only on the CLI tool output.
 
 ##### Assembly
 
-* Not so sure what to do with this one.
-* Seems to be CycloneDX specific.
+- Not so sure what to do with this one.
+- Seems to be CycloneDX specific.
 
 ##### Dependency graph
 
-* Not a new feature, it can also be done using the lock files.
-* Not sure how useful that is.
+- Not a new feature, it can also be done using the lock files.
+- Not sure how useful that is.
 
 ##### Provenance
 
-* This would be good to trust software suppliers
-* If you trust a supplier, do you trust *ALL* that it supplies?
+- This would be good to trust software suppliers
+- If you trust a supplier, do you trust _ALL_ that it supplies?
 
 ##### Pedigree
 
@@ -154,8 +155,8 @@ jq '.components[].evidence.licenses[]?.license.id' cyclonedx.sbom |sort -u
 
 ##### Packaging and distribution
 
-* This sounds great!
-* It seems to be what we would use instead of a "build tool SBOM".
+- This sounds great!
+- It seems to be what we would use instead of a "build tool SBOM".
 
 ##### Composition completeness
 

--- a/examples/maven/README.md
+++ b/examples/maven/README.md
@@ -19,7 +19,7 @@ make example-maven
 # Wait until it completes.
 tkn pr logs --last -f
 
-# to do 
+# to do
 verify jar-file
 ```
 


### PR DESCRIPTION
Some discrepancies were noticed between the Markdown autoformatting task
and the Markdown linting task. This PR aligns the configuration for the
2 tasks and fixes the CI violations.

Signed-off-by: Rémy Greinhofer <remy.greinhofer@gmail.com>
