### PR TITLE
fix git clone non-root permission issues

### DIFF
--- a/examples/examples.cue
+++ b/examples/examples.cue
@@ -48,6 +48,10 @@ for pr in frsca.pipelineRun {
 	}
 }
 
+frsca: trigger: [Name=_]: pipelineRun: spec: podTemplate: securityContext: {
+  fsGroup: 65532
+}
+
 frsca: pipelineRun: [Name=_]: spec: workspaces: [{
 	name: *"\(Name)ws" | string
 	persistentVolumeClaim: claimName: "\(Name)source-ws-pvc"


### PR DESCRIPTION
Fixes issue: https://github.com/buildsec/frsca/issues/396

Adds proper [fsGroup permission](https://github.com/tektoncd/catalog/tree/main/task/git-clone/0.9#workspaces) for git-clone task.