### PR TITLE
Configure pipeline run attestations

### DIFF
--- a/platform/components/tekton/chains/patch_config_dual_backend.yaml
+++ b/platform/components/tekton/chains/patch_config_dual_backend.yaml
@@ -3,3 +3,5 @@ data:
   artifacts.oci.storage: tekton,oci
   artifacts.taskrun.format: slsa/v1
   artifacts.taskrun.storage: tekton,oci
+  artifacts.pipelinerun.format: slsa/v1
+  artifacts.pipelinerun.storage: tekton,oci

--- a/platform/components/tekton/chains/patch_config_kms.yaml
+++ b/platform/components/tekton/chains/patch_config_kms.yaml
@@ -1,6 +1,7 @@
 data:
   artifacts.oci.signer: kms
   artifacts.taskrun.signer: kms
+  artifacts.pipelinerun.signer: kms
   signers.kms.kmsref: "hashivault://frsca"
   signers.kms.auth.address: "http://vault.vault:8200"
   signers.kms.auth.oidc.path: jwt

--- a/platform/components/tekton/chains/patch_config_oci.yaml
+++ b/platform/components/tekton/chains/patch_config_oci.yaml
@@ -2,3 +2,5 @@
 data:
   artifacts.taskrun.storage: tekton,oci
   artifacts.taskrun.format: slsa/v1
+  artifacts.pipelinerun.storage: tekton,oci
+  artifacts.pipelinerun.format: slsa/v1


### PR DESCRIPTION
This fixes a warning thrown by `tkn chain payload` because it's looking for pipelinerun attestations. Those default to x509 which we don't use in FRSCA, so the command warns that it cannot locate the x509 key. This change sets up the pipelinerun attestations to use the same settings as the taskrun attestations. Docs for the options can be found at https://tekton.dev/docs/chains/config/#pipelinerun-configuration