### PR TITLE
Update Cue v0.4.3 -> v0.5.0

### DIFF
--- a/platform/00-kubernetes-minikube-setup.sh
+++ b/platform/00-kubernetes-minikube-setup.sh
@@ -33,7 +33,7 @@ COSIGN_RELEASE_URL="https://github.com/sigstore/cosign/releases/download/${COSIG
 COSIGN_CHECKSUMS="cosign_checksums.txt"
 COSIGN_ASSET="${COSIGN_BIN}-${COSIGN_OS}-${COSIGN_ARCH}"
 
-CUE_VERSION=v0.4.3
+CUE_VERSION=v0.5.0
 CUE_FILE_NAME=cue_${CUE_VERSION}_linux_amd64.tar.gz
 CUE_URL=https://github.com/cue-lang/cue/releases/download/${CUE_VERSION}
 CUE_CHECKSUMS=checksums.txt


### PR DESCRIPTION
Release: https://github.com/cue-lang/cue/releases/tag/v0.5.0