### PR TITLE
Use internal registry with kyverno

### DIFF
--- a/.github/workflows/install-frsca.yaml
+++ b/.github/workflows/install-frsca.yaml
@@ -25,6 +25,8 @@ jobs:
 
   setup:
     runs-on: ubuntu-latest
+    env:
+      REGISTRY: "host.minikube.internal:5443"
     needs:
       lint
     name: Test FRSCA Installation
@@ -46,13 +48,9 @@ jobs:
       - name: Try the cluster !
         run: kubectl get pods -A
       - name: Initialize FRSCA
-        env:
-          REGISTRY: "registry.registry"
         run: |
           make setup-frsca
       - name: Run buildpacks pipeline
-        env:
-          REGISTRY: "registry.registry"
         run: |
           make registry-proxy >/dev/null &
           make example-buildpacks
@@ -64,7 +62,7 @@ jobs:
           fi
           sleep 60
           IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-          if [ "${REGISTRY}" = "registry.registry" ]; then
+          if [ "${REGISTRY}" = "registry.registry" ] || [ "${REGISTRY}" = "host.minikube.internal:5443" ]; then
             IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
           fi
           crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
@@ -72,9 +70,7 @@ jobs:
           cosign verify --insecure-ignore-tlog --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
           cosign verify-attestation --insecure-ignore-tlog --type slsaprovenance --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
           kill %?registry-proxy
-      - name: Run sample pipeline to test kyverno
-        env:
-          REGISTRY: "registry.registry"
+      - name: Run sample pipeline to test admission controller
         run: |
           make registry-proxy >/dev/null &
           make example-sample-pipeline
@@ -86,7 +82,7 @@ jobs:
           fi
           sleep 60
           IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name == "IMAGE_URL") | .value')
-          if [ "${REGISTRY}" = "registry.registry" ]; then
+          if [ "${REGISTRY}" = "registry.registry" ] || [ "${REGISTRY}" = "host.minikube.internal:5443" ]; then
             IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:5000#')"
           fi
           crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"

--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -47,11 +47,11 @@ The examples use the [ttl.sh](https://ttl.sh) registry to upload images by
 default. It is possible to change it to another registry of your choice by
 exporting the `$REGISTRY` variable.
 
-You may also use the local registry deployed inside the cluster. This requires
-setting the variable to `registry.registry`:
+You may also use the local registry deployed inside the minikube cluster. This
+requires setting the variable to `host.minikube.internal:5443`:
 
 ```bash
-export REGISTRY=registry.registry
+export REGISTRY=host.minikube.internal:5443
 ```
 
 Then to access the registry outside of minikube, open a separate terminal and

--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -9,7 +9,7 @@ Execute the following commands from the root of this repository:
 make setup-minikube
 
 # Use the built-in registry, or replace with your own local registry
-export REGISTRY=registry.registry
+export REGISTRY=host.minikube.internal:5443
 
 # Setup FRSCA environment
 make setup-frsca
@@ -32,7 +32,7 @@ tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/s
 # Export the value of IMAGE_URL from the last pipeline run and the associated taskrun name:
 IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
 TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
-if [ "${REGISTRY}" = "registry.registry" ]; then
+if [ "${REGISTRY}" = "registry.registry" ] || [ "${REGISTRY}" = "host.minikube.internal:5443" ]; then
   : "${REGISTRY_PORT:=5000}"
   IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi

--- a/examples/cosign/README.md
+++ b/examples/cosign/README.md
@@ -12,7 +12,7 @@ Execute the following commands from the root of this repository:
 make setup-minikube
 
 # Use the built-in registry, or replace with your own local registry
-export REGISTRY=registry.registry
+export REGISTRY=host.minikube.internal:5443
 
 # Setup FRSCA environment
 make setup-frsca
@@ -31,7 +31,7 @@ tkn pr logs --last -f
 # Export the value of IMAGE_URL from the last taskrun and the taskrun name:
 IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name == "IMAGE_URL") | .value')
 TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name == "IMAGE_URL") | .k')
-if [ "${REGISTRY}" = "registry.registry" ]; then
+if [ "${REGISTRY}" = "registry.registry" ] || [ "${REGISTRY}" = "host.minikube.internal:5443" ]; then
   : "${REGISTRY_PORT:=5000}"
   IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi

--- a/examples/go-pipeline/README.md
+++ b/examples/go-pipeline/README.md
@@ -17,7 +17,7 @@ auto determine the architecture.
 make setup-minikube
 
 # Use the built-in registry, or replace with your own local registry
-export REGISTRY=registry.registry
+export REGISTRY=host.minikube.internal:5443
 
 # Setup FRSCA environment
 make setup-frsca
@@ -34,7 +34,7 @@ tkn pr logs --last -f
 # Export the value of IMAGE_URL from the last taskrun and the taskrun name:
 IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name == "IMAGE_URL") | .value')
 TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name == "IMAGE_URL") | .k')
-if [ "${REGISTRY}" = "registry.registry" ]; then
+if [ "${REGISTRY}" = "registry.registry" ] || [ "${REGISTRY}" = "host.minikube.internal:5443" ]; then
   : "${REGISTRY_PORT:=5000}"
   IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi

--- a/examples/gradle-pipeline/README.md
+++ b/examples/gradle-pipeline/README.md
@@ -11,7 +11,7 @@ This is a sample Gradle tekton pipeline.
 make setup-minikube
 
 # Use the built-in registry, or replace with your own local registry
-export REGISTRY=registry.registry
+export REGISTRY=host.minikube.internal:5443
 
 # Setup FRSCA environment
 make setup-frsca
@@ -28,7 +28,7 @@ tkn pr logs --last -f
 # Export the value of IMAGE_URL from the last pipeline run and the associated taskrun name:
 IMAGE_URL="$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')"
 TASK_RUN="$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')"
-if [ "${REGISTRY}" = "registry.registry" ]; then
+if [ "${REGISTRY}" = "registry.registry" ] || [ "${REGISTRY}" = "host.minikube.internal:5443" ]; then
   : "${REGISTRY_PORT:=5000}"
   IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi

--- a/examples/ibm-tutorial/README.md
+++ b/examples/ibm-tutorial/README.md
@@ -7,7 +7,7 @@
 make setup-minikube
 
 # Use the built-in registry, or replace with your own local registry
-export REGISTRY=registry.registry
+export REGISTRY=host.minikube.internal:5443
 
 # Setup FRSCA environment
 make setup-frsca
@@ -30,7 +30,7 @@ tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/s
 # Export the value of IMAGE_URL from the last pipeline run and the associated taskrun name:
 IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name == "IMAGE_URL") | .value')
 TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name == "IMAGE_URL") | .k')
-if [ "${REGISTRY}" = "registry.registry" ]; then
+if [ "${REGISTRY}" = "registry.registry" ] || [ "${REGISTRY}" = "host.minikube.internal:5443" ]; then
   : "${REGISTRY_PORT:=5000}"
   IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi

--- a/examples/sample-pipeline/README.md
+++ b/examples/sample-pipeline/README.md
@@ -17,7 +17,7 @@ application.
 make setup-minikube
 
 # Use the built-in registry, or replace with your own local registry
-export REGISTRY=registry.registry
+export REGISTRY=host.minikube.internal:5443
 
 # Setup FRSCA environment
 make setup-frsca
@@ -34,7 +34,7 @@ tkn pr logs --last -f
 # Export the value of IMAGE_URL from the last taskrun and the taskrun name:
 IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name == "IMAGE_URL") | .value')
 TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name == "IMAGE_URL") | .k')
-if [ "${REGISTRY}" = "registry.registry" ]; then
+if [ "${REGISTRY}" = "registry.registry" ] || [ "${REGISTRY}" = "host.minikube.internal:5443" ]; then
   : "${REGISTRY_PORT:=5000}"
   IMAGE_URL="$(echo "${IMAGE_URL}" | sed 's#'${REGISTRY}'#127.0.0.1:'${REGISTRY_PORT}'#')"
 fi

--- a/examples/sample-pipeline/sample-pipeline.cue
+++ b/examples/sample-pipeline/sample-pipeline.cue
@@ -202,7 +202,7 @@ frsca: task: "deploy-using-kubectl": {
 				"-e",
 				"s;__DIGEST__;$(params.imageDigest);g",
 				"-e",
-				"s;registry.registry/;localhost:5000/;g",
+				"s;registry.registry/;host.minikube.internal:5443/;g",
 				"$(workspaces.git-source.path)/$(params.pathToYamlFile)",
 			]
 			command: [

--- a/platform/00-kubernetes-minikube-setup.sh
+++ b/platform/00-kubernetes-minikube-setup.sh
@@ -234,6 +234,7 @@ else
     --extra-config=apiserver.service-account-issuer=api \
     --extra-config=apiserver.api-audiences=api,spire-server \
     --extra-config=apiserver.authorization-mode=Node,RBAC \
+    --insecure-registry=host.minikube.internal:5443 \
     --memory max
 fi
 

--- a/platform/02-setup-certs.sh
+++ b/platform/02-setup-certs.sh
@@ -7,7 +7,7 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 C_GREEN='\033[32m'
 C_RESET_ALL='\033[0m'
 
-for ns in cert-manager gitea registry spire tekton-chains tekton-pipelines vault; do
+for ns in cert-manager cosign-system gitea kyverno registry spire tekton-chains tekton-pipelines vault; do
   kubectl create namespace "${ns}" --dry-run=client -o=yaml | kubectl apply -f -
 done
 
@@ -59,7 +59,7 @@ docker run --rm -v "${ca_cert}:/tmp/cert.pem:ro,z" --entrypoint /bin/bash \
 
 # TODO: This should be changed to using a volume instead of a value directly in a config map
 #       as it would make it much more straightforward.
-for ns in default gitea registry tekton-chains tekton-pipelines; do
+for ns in default cosign-system gitea kyverno registry tekton-chains tekton-pipelines; do
   kubectl -n "${ns}" create configmap ca-certs \
     --from-file=ca-certificates.crt="${ca_bundle}" \
     --dry-run=client -o=yaml | kubectl apply --server-side=true -f -

--- a/platform/05-registry-proxy.sh
+++ b/platform/05-registry-proxy.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Port forward the internal registry
 : "${REGISTRY_PORT:=5000}"
+: "${REGISTRY_PORT_HTTPS:=5443}"
 : "${REGISTRY:=localhost:${REGISTRY_PORT}}"
 C_GREEN='\033[32m'
 C_CYAN='\033[36m'
@@ -11,4 +12,5 @@ C_RESET_ALL='\033[0m'
 echo -e "${C_GREEN}Port forwarding the registry: REGISTRY=${REGISTRY}${C_RESET_ALL}"
 echo -e "${C_CYAN}e.g.: curl http://${REGISTRY}/v2/_catalog${C_RESET_ALL}"
 K8S_REGISTRY_PORT=$(kubectl get svc registry -n registry -o 'jsonpath={.spec.ports[?(@.name=="http")].port}')
-kubectl port-forward --address 0.0.0.0 -n registry service/registry "${REGISTRY_PORT}":"$K8S_REGISTRY_PORT"
+K8S_REGISTRY_PORT_HTTPS=$(kubectl get svc registry -n registry -o 'jsonpath={.spec.ports[?(@.name=="https")].port}')
+kubectl port-forward --address 0.0.0.0 -n registry service/registry "${REGISTRY_PORT}":"$K8S_REGISTRY_PORT" "${REGISTRY_PORT_HTTPS}":"${K8S_REGISTRY_PORT_HTTPS}"

--- a/platform/components/cert-manager/registry.yaml
+++ b/platform/components/cert-manager/registry.yaml
@@ -12,6 +12,8 @@ spec:
     - registry.registry.svc.cluster.local
     - registry.registry
     - registry
+    - host.minikube.internal
+    - host.minikube.internal:5443
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/platform/components/kyverno/patch_ca_certs.json
+++ b/platform/components/kyverno/patch_ca_certs.json
@@ -1,0 +1,52 @@
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "$setElementOrder/containers": [
+          {
+            "name": "kyverno"
+          }
+        ],
+        "$setElementOrder/volumes": [
+          {
+            "name": "signing-secrets"
+          },
+          {
+            "name": "oidc-info"
+          },
+          {
+            "name": "ca-certs"
+          }
+        ],
+        "containers": [
+          {
+            "$setElementOrder/volumeMounts": [
+              {
+                "mountPath": "/.sigstore"
+              },
+              {
+                "mountPath": "/etc/ssl/certs/"
+              }
+            ],
+            "name": "kyverno",
+            "volumeMounts": [
+              {
+                "mountPath": "/etc/ssl/certs/",
+                "name": "ca-certs",
+                "readOnly": true
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "configMap": {
+              "name": "ca-certs"
+            },
+            "name": "ca-certs"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/platform/components/registry/registry.yaml
+++ b/platform/components/registry/registry.yaml
@@ -29,7 +29,7 @@ data:
         disable: false
     http:
       addr: :5000
-      relativeurls: false
+      relativeurls: true
     validation:
       disabled: true
     compatibility:
@@ -171,6 +171,7 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
+              hostPort: 5443
           livenessProbe:
             failureThreshold: 2
             httpGet:
@@ -223,17 +224,20 @@ metadata:
   labels:
     app: registry
     component: proxy
+    instance: http
   name: registry-proxy
 spec:
   selector:
     matchLabels:
       app: registry
       component: proxy
+      instance: http
   template:
     metadata:
       labels:
         app: registry
         component: proxy
+        instance: http
     spec:
       containers:
         - image: "gcr.io/google_containers/kube-registry-proxy:0.4@sha256:1040f25a5273de0d72c54865a8efd47e3292de9fb8e5353e3fa76736b854f2da"
@@ -248,3 +252,5 @@ spec:
               value: registry
             - name: REGISTRY_PORT
               value: "5000"
+
+# TODO: add a port forward for 5443:443 for multi-node clusters using the internal registry

--- a/resources/kyverno/admission-control-policy/admission-control-verify-attestation.cue
+++ b/resources/kyverno/admission-control-policy/admission-control-verify-attestation.cue
@@ -1,45 +1,50 @@
 package frsca
 
 frsca: clusterPolicy: "attest-code-review": {
-	spec: rules: [{
-		verifyImages: [{
-			image: #public.repo
-			attestations: [{
-				predicateType: "https://slsa.dev/provenance/v0.2"
-				conditions: [{
-					all: [{
-						key:      "{{ builder.id }}"
-						operator: "Equals"
-						value:    "https://tekton.dev/chains/v2"
-					}, {
-						key:      "{{ buildType }}"
-						operator: "Equals"
-						value:    "tekton.dev/v1beta1/TaskRun"
+	spec: {
+		validationFailureAction: "Audit"
+		rules: [{
+			verifyImages: [{
+				image: #public.repo
+				mutateDigest: false
+				attestations: [{
+					predicateType: "https://slsa.dev/provenance/v0.2"
+					conditions: [{
+						all: [{
+							key:      "{{ builder.id }}"
+							operator: "Equals"
+							value:    "https://tekton.dev/chains/v2"
+						}, {
+							key:      "{{ buildType }}"
+							operator: "Equals"
+							value:    "tekton.dev/v1beta1/TaskRun"
+						}]
 					}]
 				}]
-			}]
-			key: "{{ keys.data.ttlsh }}"
-		}, {
-			image: "gcr.io/tekton-releases/github.com/tektoncd/*"
-			attestations: [{
-				predicateType: "https://slsa.dev/provenance/v0.2"
-				conditions: [{
-					all: [{
-						key:      "{{ builder.id }}"
-						operator: "Equals"
-						value:    "https://tekton.dev/chains/v2"
-					}, {
-						key:      "{{ buildType }}"
-						operator: "Equals"
-						value:    "https://tekton.dev/attestations/chains@v2"
+				key: "{{ keys.data.frscakey }}"
+			}, {
+				image: "gcr.io/tekton-releases/github.com/tektoncd/*"
+				mutateDigest: false
+				attestations: [{
+					predicateType: "https://slsa.dev/provenance/v0.2"
+					conditions: [{
+						all: [{
+							key:      "{{ builder.id }}"
+							operator: "Equals"
+							value:    "https://tekton.dev/chains/v2"
+						}, {
+							key:      "{{ buildType }}"
+							operator: "Equals"
+							value:    "https://tekton.dev/attestations/chains@v2"
+						}]
 					}]
 				}]
+				key: "{{ keys.data.tektoncd }}"
 			}]
-			key: "{{ keys.data.tektoncd }}"
+			match: resources: namespaces: ["tekton-pipelines",
+				"tekton-chains",
+				"prod"]
 		}]
-		match: resources: namespaces: ["tekton-pipelines",
-			"tekton-chains",
-			"prod"]
-	}]
+	}
 	metadata: annotations: "pod-policies.kyverno.io/autogen-controllers": "none"
 }

--- a/resources/kyverno/admission-control-policy/admission-control-verify-image-resources.cue
+++ b/resources/kyverno/admission-control-policy/admission-control-verify-image-resources.cue
@@ -17,6 +17,6 @@ frsca: configMap: "\(#keys.name)": {
 			-----END PUBLIC KEY-----
 			"""
 
-		ttlsh: #public.key
+		frscakey: #public.key
 	}
 }

--- a/resources/kyverno/admission-control-policy/admission-control-verify-image.cue
+++ b/resources/kyverno/admission-control-policy/admission-control-verify-image.cue
@@ -9,8 +9,8 @@ frsca: clusterPolicy: "verify-image": {
 			image: "gcr.io/projectsigstore/*"
 			key:   "{{ keys.data.projectsigstore }}"
 		}, {
-			image: "ttl.sh/*"
-			key:   "{{ keys.data.ttlsh }}"
+			image: #public.repo
+			key:   "{{ keys.data.frscakey }}"
 		}, {
 			image:   "ghcr.io/google/ko"
 			subject: "https://github.com/google/ko/*"

--- a/resources/kyverno/admission-control-policy/kyverno.cue
+++ b/resources/kyverno/admission-control-policy/kyverno.cue
@@ -11,7 +11,7 @@ package frsca
 }
 
 frsca: clusterPolicy: [Name=_]: spec: {
-	validationFailureAction: "enforce"
+	validationFailureAction: *"Enforce" | string
 	background:              false
 	webhookTimeoutSeconds:   *30 | int
 	failurePolicy:           "Fail"


### PR DESCRIPTION
This follows #436. It changes the registry from 127.0.0.1 or registry.registry to the minikube internal name which can also be used by both admission controllers running in a pod and the k8s node pulling the images. This does require the registry-proxy to be running in the background.

Because of #430, the attestation admission control policy is set to `validationFailureAction: "Audit"`.