### PR TITLE
Fix linting on email address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -63,7 +63,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-conduct@openssf.org. All complaints will be reviewed and investigated promptly
+<conduct@openssf.org>. All complaints will be reviewed and investigated promptly
 and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
markdownlint v0.7.0 was just released yesterday and it fails on bare email addresses.